### PR TITLE
Fixing README that mentioned wrong arguments.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ class while passing it your template and (optionally) a context dict::
   from template_email import TemplateEmail
   
   context = {'first_name': user.first_name}
-  email = TemplateEmail(template='email/confirmation_message.html', context)
+  email = TemplateEmail(template='email/confirmation_message.html', context=context)
   email.send()
 
 


### PR DESCRIPTION
If you copied the code example from the docs, you would get a SyntaxError because it used positional arguments after a keyword argument.
